### PR TITLE
Apply default ruff rules

### DIFF
--- a/caravel/configure.py
+++ b/caravel/configure.py
@@ -13,7 +13,6 @@ properly.
 
 # System import
 import importlib
-import distutils
 
 # Package import
 from .info import __version__
@@ -48,7 +47,7 @@ def _check_python_versions():
             mod_name = "progressbar"
         try:
             mod_install_version = importlib.import_module(mod_name).__version__
-        except:
+        except Exception:
             mod_install_version = "?"
         versions[mod_name] = (operator + mod_min_version, mod_install_version)
     return versions

--- a/caravel/loaders/_csv.py
+++ b/caravel/loaders/_csv.py
@@ -12,7 +12,6 @@ This module defines the CSV dataset loader.
 
 # Third party import
 import pandas as pd
-import math
 
 # Package import
 from .loader_base import LoaderBase
@@ -30,7 +29,7 @@ class CSV(LoaderBase):
         Parameters
         ----------
         path: str
-            the path to the table to be loaded.
+            the path to the CSV file to load.
         **kwargs: see pd.read_csv.
 
         Returns
@@ -42,14 +41,14 @@ class CSV(LoaderBase):
         return pd.read_csv(path, header=header_type, sep=separator,
                 usecols=usecols, nrows=nrows, skiprows=skiprows)
 
-    def save(self, data, outpath):
+    def save(self, data, path):
         """ A method that save the table.
 
         Parameters
         ----------
         data: pandas DataFrame
             the table to be saved.
-        outpath: str
-            the path where the the table will be saved.
+        path: str
+            the path to the CSV file to save the table into.
         """
-        data.to_csv(outpath)
+        data.to_csv(path)

--- a/caravel/loaders/_json.py
+++ b/caravel/loaders/_json.py
@@ -39,14 +39,14 @@ class JSON(LoaderBase):
             data = json.load(open_file)
         return data
 
-    def save(self, data, outpath):
+    def save(self, data, path):
         """ A method that save the data in a JSON file.
 
         Parameters
         ----------
         data: object
             the data to be saved.
-        outpath: str
+        path: str
             the path where the the data will be saved.
         """
         with open(path, "wt") as open_file:

--- a/caravel/loaders/_xlsx.py
+++ b/caravel/loaders/_xlsx.py
@@ -12,7 +12,6 @@ This module defines the XLSX dataset loader.
 
 # Third party import
 import pandas as pd
-import math
 
 # Package import
 from .loader_base import LoaderBase

--- a/caravel/parser.py
+++ b/caravel/parser.py
@@ -12,6 +12,7 @@ This module contains the generic parser definition.
 
 # Imports
 import re
+import warnings
 from string import Formatter
 from itertools import product
 

--- a/caravel/parsers/cw.py
+++ b/caravel/parsers/cw.py
@@ -10,9 +10,6 @@
 This module contains the CubicWeb parser definition.
 """
 
-# System import
-import os
-
 # Third party import
 import numpy as np
 import pandas as pd

--- a/caravel/parsers/parser_base.py
+++ b/caravel/parsers/parser_base.py
@@ -254,7 +254,7 @@ class ParserBase(object):
                     path = path.replace(replace[0], replace[1])
                 try:
                     _data = load(path)
-                except:
+                except Exception:
                     _data = None
                 if isinstance(_data, pd.DataFrame):
                     layout = self._load_layout(name)

--- a/examples/bids/bids_users.py
+++ b/examples/bids/bids_users.py
@@ -14,6 +14,8 @@ In order to test if pycaravel package is installed on your machine, you can
 check the package version.
 """
 
+from pprint import pprint
+
 import caravel
 
 print(caravel.__version__)
@@ -41,8 +43,6 @@ parser = caravel.get_parser(
 # You can now list the available configurations for your project, and the
 # available layout representations pre-generated. Note that these
 # representations are sorted by dates, and that the latest one will be used.
-
-from pprint import pprint
 
 pprint(parser.conf)
 pprint(parser.representation)

--- a/setup.py
+++ b/setup.py
@@ -9,17 +9,8 @@
 
 
 # System import
-from __future__ import print_function
 import os
-import re
-import sys
-import platform
-import subprocess
-from pprint import pprint
-from distutils.version import LooseVersion
-from setuptools.command.build_ext import build_ext
-from setuptools import setup, find_packages, Extension
-from setuptools.command.test import test as TestCommand
+from setuptools import setup, find_packages
 
 
 # Package information


### PR DESCRIPTION
Leave out `__init__.py` and CubicWeb files.